### PR TITLE
Introduce an input system around raylib

### DIFF
--- a/src/ConfigFile.zig
+++ b/src/ConfigFile.zig
@@ -1,13 +1,23 @@
+const std = @import("std");
 const raylib = @import("raylib");
-const KeyboardKey = raylib.KeyboardKey;
+const Input = @import("Input.zig");
 
-pub const KeyMapping = struct {
-    none: KeyboardKey = KeyboardKey.KEY_NULL,
-    toggle_menu: KeyboardKey = KeyboardKey.KEY_P,
-    toggle_edit: KeyboardKey = KeyboardKey.KEY_E,
-    purge_life: KeyboardKey = KeyboardKey.KEY_K,
-    toggle_stop: KeyboardKey = KeyboardKey.KEY_SPACE,
-};
+const Allocator = std.mem.Allocator;
+const KeyboardKey = raylib.KeyboardKey;
+const MouseButton = raylib.MouseButton;
+const InputBinding = Input.InputBinding;
+
+const Self = @This();
+
+// TODO: use an external configuration file, using "YAML"|"TOML"|"JSON"
+
+var buf: [1000]u8 = undefined;
+var allocator: Allocator = std.heap.page_allocator;
+
+video: Video = .{},
+action_map: ActionMap = undefined,
+
+pub const ActionMap = std.StringHashMap(InputBinding);
 
 const Video = struct {
     resolution: [2]u16 = [_]u16{ 1280, 720 },
@@ -15,5 +25,23 @@ const Video = struct {
     target_fps: u8 = 60,
 };
 
-pub const video: Video = .{};
-pub const keymap: KeyMapping = .{};
+pub fn init() !Self {
+    var self = Self{ .action_map = ActionMap.init(allocator) };
+
+    try self.action_map.put("none", .{ .key = .KEY_NULL });
+    try self.action_map.put("toggle_menu", .{ .key = .KEY_P });
+    try self.action_map.put("toggle_edit", .{ .key = .KEY_E });
+    try self.action_map.put("toggle_pause", .{ .key = .KEY_SPACE });
+    try self.action_map.put("purge_life", .{ .key = .KEY_K });
+    try self.action_map.put("translate_cam", .{ .mouse_button = .MOUSE_BUTTON_RIGHT });
+    try self.action_map.put("zoom_in", .{ .key = .KEY_EQUAL });
+    try self.action_map.put("zoom_out", .{ .key = .KEY_MINUS });
+
+    return self;
+}
+
+pub fn deinit(self: *Self) void {
+    self.action_map.deinit();
+
+    self.* = undefined;
+}

--- a/src/ConfigFile.zig
+++ b/src/ConfigFile.zig
@@ -1,3 +1,14 @@
+const raylib = @import("raylib");
+const KeyboardKey = raylib.KeyboardKey;
+
+pub const KeyMapping = struct {
+    none: KeyboardKey = KeyboardKey.KEY_NULL,
+    toggle_menu: KeyboardKey = KeyboardKey.KEY_P,
+    toggle_edit: KeyboardKey = KeyboardKey.KEY_E,
+    purge_life: KeyboardKey = KeyboardKey.KEY_K,
+    toggle_stop: KeyboardKey = KeyboardKey.KEY_SPACE,
+};
+
 const Video = struct {
     resolution: [2]u16 = [_]u16{ 1280, 720 },
     fullscreen: bool = false,
@@ -5,3 +16,4 @@ const Video = struct {
 };
 
 pub const video: Video = .{};
+pub const keymap: KeyMapping = .{};

--- a/src/Game.zig
+++ b/src/Game.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const Self = @This();
 const Resources = @import("Resources.zig");
+const Input = @import("Input.zig");
 
 const initial_state = State.gameplay;
 
@@ -84,7 +85,7 @@ fn callOnState(self: *Self, state: State, comptime fun: []const u8, args: anytyp
     }
 }
 
-pub fn update(self: *Self, delta_time: f32) !void {
+pub fn update(self: *Self, input: Input, delta_time: f32) !void {
     defer self.update_time += delta_time;
 
     if (self.next_state != null) {
@@ -107,7 +108,7 @@ pub fn update(self: *Self, delta_time: f32) !void {
     }
 
     switch (self.current_state) {
-        .state => |state| try self.callOnState(state, "update", .{ self.update_time, delta_time }),
+        .state => |state| try self.callOnState(state, "update", .{ input, self.update_time, delta_time }),
         .transition => {}, // do not update game logic in transitions
     }
 }

--- a/src/Input.zig
+++ b/src/Input.zig
@@ -1,0 +1,42 @@
+const raylib = @import("raylib");
+
+const Self = @This();
+const KeyMapping = @import("ConfigFile.zig").KeyMapping;
+
+keymap: KeyMapping,
+
+const KeyAction = enum(usize) {
+    none = 0,
+    toggle_menu,
+    toggle_edit,
+    purge_life,
+    toggle_stop,
+};
+
+fn mapAction(self: Self, key_action: KeyAction) raylib.KeyboardKey {
+    switch (key_action) {
+        .none => return self.keymap.none,
+
+        .toggle_menu => return self.keymap.toggle_menu,
+        .toggle_edit => return self.keymap.toggle_edit,
+        .purge_life => return self.keymap.purge_life,
+        .toggle_stop => return self.keymap.toggle_stop,
+    }
+}
+
+pub fn init(keymap: KeyMapping) Self {
+    return Self{ .keymap = keymap };
+}
+
+pub fn isKeyPressed(self: Self, key_action: KeyAction) bool {
+    const key = self.mapAction(key_action);
+    const result: bool = raylib.IsKeyPressed(key);
+
+    return result;
+}
+
+pub fn isAnyHit(self: Self) bool {
+    _ = self;
+
+    return false;
+}

--- a/src/Resources.zig
+++ b/src/Resources.zig
@@ -3,12 +3,40 @@ const raylib = @import("raylib");
 const Self = @This();
 const GameOfLife = @import("GameOfLife.zig");
 
-// This is some kinda shared contex between states, I looking for better way
-// to do it but for the moment this is the solution.
-
 gol: GameOfLife = undefined,
 cam: raylib.Camera2D = .{ .zoom = 1.0, .target = undefined },
+zoom_increment: f32 = 0.125,
 
 pub fn init() Self {
     return Self{ .gol = GameOfLife.init() };
+}
+
+pub fn zoomIn(self: *Self) void {
+    const delta = 2.0;
+    var mouse_world_pos = raylib.GetScreenToWorld2D(raylib.GetMousePosition(), self.cam);
+
+    self.cam.offset = raylib.GetMousePosition();
+
+    self.cam.target = mouse_world_pos;
+
+    self.cam.zoom += (delta * self.zoom_increment);
+
+    if (self.cam.zoom < self.zoom_increment) {
+        self.cam.zoom = self.zoom_increment;
+    }
+}
+
+pub fn zoomOut(self: *Self) void {
+    const delta = -2.0;
+    var mouse_world_pos = raylib.GetScreenToWorld2D(raylib.GetMousePosition(), self.cam);
+
+    self.cam.offset = raylib.GetMousePosition();
+
+    self.cam.target = mouse_world_pos;
+
+    self.cam.zoom += (delta * self.zoom_increment);
+
+    if (self.cam.zoom < self.zoom_increment) {
+        self.cam.zoom = self.zoom_increment;
+    }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,18 +7,32 @@ const Config = @import("ConfigFile.zig");
 const Input = @import("Input.zig");
 
 pub fn main() !void {
-    const input = Input.init(Config.keymap);
     var resources = Resources.init();
+    var config = try Config.init();
     var game = try Game.init(&resources);
-    defer game.deinit();
+    const input = Input.init(&config.action_map);
 
-    raylib.InitWindow(Config.video.resolution[0], Config.video.resolution[1], "zell-life");
-    raylib.SetConfigFlags(raylib.ConfigFlags{ .FLAG_WINDOW_RESIZABLE = true });
-    raylib.SetTargetFPS(Config.video.target_fps);
+    defer {
+        game.deinit();
+        config.deinit();
+    }
+
+    raylib.SetConfigFlags(raylib.ConfigFlags{
+        .FLAG_WINDOW_RESIZABLE = true,
+        .FLAG_FULLSCREEN_MODE = config.video.fullscreen,
+    });
+
+    raylib.InitWindow(config.video.resolution[0], config.video.resolution[1], "zell-life");
+    raylib.SetTargetFPS(config.video.target_fps);
 
     defer raylib.CloseWindow();
 
     while (!raylib.WindowShouldClose()) {
+        if (raylib.IsWindowResized() and !raylib.IsWindowFullscreen()) {
+            config.video.resolution[0] = @intCast(raylib.GetScreenWidth());
+            config.video.resolution[1] = @intCast(raylib.GetScreenHeight());
+        }
+
         try game.update(input, 0);
         try game.render(0);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -4,8 +4,10 @@ const std = @import("std");
 const Game = @import("Game.zig");
 const Resources = @import("Resources.zig");
 const Config = @import("ConfigFile.zig");
+const Input = @import("Input.zig");
 
 pub fn main() !void {
+    const input = Input.init(Config.keymap);
     var resources = Resources.init();
     var game = try Game.init(&resources);
     defer game.deinit();
@@ -17,7 +19,7 @@ pub fn main() !void {
     defer raylib.CloseWindow();
 
     while (!raylib.WindowShouldClose()) {
-        try game.update(0);
+        try game.update(input, 0);
         try game.render(0);
     }
 }

--- a/src/states/EditGrid.zig
+++ b/src/states/EditGrid.zig
@@ -4,6 +4,7 @@ const raylib = @import("raylib");
 const Self = @This();
 const Game = @import("../Game.zig");
 const Resources = @import("../Resources.zig");
+const Input = @import("../Input.zig");
 const GameOfLife = @import("../GameOfLife.zig");
 
 resources: *Resources,
@@ -19,11 +20,11 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
-pub fn update(self: *Self, total_time: f32, delta_time: f32) !void {
+pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void {
     _ = total_time;
     _ = delta_time;
 
-    if (raylib.IsKeyPressed(.KEY_E)) {
+    if (input.isKeyPressed(.toggle_edit)) {
         Game.fromComponent(self).switchToState(.gameplay);
     }
 

--- a/src/states/EditGrid.zig
+++ b/src/states/EditGrid.zig
@@ -10,7 +10,6 @@ const GameOfLife = @import("../GameOfLife.zig");
 resources: *Resources,
 
 cam: *raylib.Camera2D,
-zoom_increment: f32 = 0.125,
 
 pub fn init(resources: *Resources) !Self {
     return Self{ .resources = resources, .cam = &resources.cam };
@@ -24,11 +23,11 @@ pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void
     _ = total_time;
     _ = delta_time;
 
-    if (input.isKeyPressed(.toggle_edit)) {
+    if (input.isActionJustPressed(.toggle_edit)) {
         Game.fromComponent(self).switchToState(.gameplay);
     }
 
-    if (raylib.IsMouseButtonPressed(.MOUSE_BUTTON_LEFT)) {
+    if (raylib.IsMouseButtonDown(.MOUSE_BUTTON_LEFT)) {
         const mouse_screen_pos = raylib.GetMousePosition();
         var mouse_world_pos = raylib.GetScreenToWorld2D(mouse_screen_pos, self.cam.*);
 
@@ -38,34 +37,25 @@ pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void
 
             self.resources.gol.toggleCellState(cell_x, cell_y) catch |err| {
                 if (err == error.OutOfBounds) {
-                    std.debug.print("EditGrid: resources.gol index out of bounds (x: {d}, y: {d})\n", .{ cell_x, cell_y });
+                    std.debug.print("[INFO] (EditGrid): resources.gol index out of bounds (x: {d}, y: {d})\n", .{ cell_x, cell_y });
                 }
                 return;
             };
         }
     }
 
-    // Translate based on mouse right click
-    if (raylib.IsMouseButtonDown(.MOUSE_BUTTON_RIGHT)) {
+    if (input.isActionPressed(.translate_cam)) {
         var delta = raylib.GetMouseDelta();
         delta = raylib.Vector2Scale(delta, -1.0 / self.cam.zoom);
 
         self.cam.target = raylib.Vector2Add(self.cam.target, delta);
     }
 
-    // Zoom based on mouse wheel
     var wheel: f32 = raylib.GetMouseWheelMove();
-    if (wheel != 0) {
-        var mouse_world_pos = raylib.GetScreenToWorld2D(raylib.GetMousePosition(), self.cam.*);
-
-        self.cam.offset = raylib.GetMousePosition();
-
-        self.cam.target = mouse_world_pos;
-
-        self.cam.zoom += (wheel * self.zoom_increment);
-        if (self.cam.zoom < self.zoom_increment) {
-            self.cam.zoom = self.zoom_increment;
-        }
+    if (input.isActionPressed(.zoom_in) or wheel > 0) {
+        self.resources.zoomIn();
+    } else if (input.isActionPressed(.zoom_out) or wheel < 0) {
+        self.resources.zoomOut();
     }
 }
 

--- a/src/states/FreezeTime.zig
+++ b/src/states/FreezeTime.zig
@@ -27,32 +27,22 @@ pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void
     _ = total_time;
     _ = delta_time;
 
-    if (input.isKeyPressed(.toggle_stop)) {
+    if (input.isActionJustPressed(.toggle_pause)) {
         Game.fromComponent(self).switchToState(.gameplay);
     }
 
-    // Translate based on mouse right click
-    if (raylib.IsMouseButtonDown(.MOUSE_BUTTON_RIGHT)) {
+    if (input.isActionPressed(.translate_cam)) {
         var delta = raylib.GetMouseDelta();
         delta = raylib.Vector2Scale(delta, -1.0 / self.cam.zoom);
 
         self.cam.target = raylib.Vector2Add(self.cam.target, delta);
     }
 
-    // Zoom based on mouse wheel
     var wheel: f32 = raylib.GetMouseWheelMove();
-    if (wheel != 0) {
-        var mouse_world_pos = raylib.GetScreenToWorld2D(raylib.GetMousePosition(), self.cam.*);
-
-        self.cam.offset = raylib.GetMousePosition();
-
-        self.cam.target = mouse_world_pos;
-
-        const zoom_increment: f32 = 0.125;
-        self.cam.zoom += (wheel * zoom_increment);
-        if (self.cam.zoom < zoom_increment) {
-            self.cam.zoom = zoom_increment;
-        }
+    if (input.isActionPressed(.zoom_in) or wheel > 0) {
+        self.resources.zoomIn();
+    } else if (input.isActionPressed(.zoom_out) or wheel < 0) {
+        self.resources.zoomOut();
     }
 }
 

--- a/src/states/FreezeTime.zig
+++ b/src/states/FreezeTime.zig
@@ -5,6 +5,7 @@ const FixedBufferAllocator = std.heap.FixedBufferAllocator;
 const Self = @This();
 const Game = @import("../Game.zig");
 const Resources = @import("../Resources.zig");
+const Input = @import("../Input.zig");
 const GameOfLife = @import("../GameOfLife.zig");
 
 var buf: [256]u8 = undefined;
@@ -22,11 +23,11 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
-pub fn update(self: *Self, total_time: f32, delta_time: f32) !void {
+pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void {
     _ = total_time;
     _ = delta_time;
 
-    if (raylib.IsKeyPressed(.KEY_SPACE)) {
+    if (input.isKeyPressed(.toggle_stop)) {
         Game.fromComponent(self).switchToState(.gameplay);
     }
 

--- a/src/states/PauseMenu.zig
+++ b/src/states/PauseMenu.zig
@@ -3,6 +3,7 @@ const raylib = @import("raylib");
 
 const Self = @This();
 const Game = @import("../Game.zig");
+const Input = @import("../Input.zig");
 
 // TODO: add option to purge all the cells. (GameOfLife.cellPurgeProtocol())
 // TODO: add option to resume game of life.
@@ -15,11 +16,11 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
-pub fn update(self: *Self, total_time: f32, delta_time: f32) !void {
+pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void {
     _ = total_time;
     _ = delta_time;
 
-    if (raylib.IsKeyPressed(.KEY_SPACE)) {
+    if (input.isAnyHit()) {
         Game.fromComponent(self).switchToState(.gameplay);
     }
 }

--- a/src/states/PauseMenu.zig
+++ b/src/states/PauseMenu.zig
@@ -20,7 +20,7 @@ pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void
     _ = total_time;
     _ = delta_time;
 
-    if (input.isAnyHit()) {
+    if (input.isActionJustPressed(.toggle_menu)) {
         Game.fromComponent(self).switchToState(.gameplay);
     }
 }

--- a/src/states/Running.zig
+++ b/src/states/Running.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const raylib = @import("raylib");
+
 const FixedBufferAllocator = std.heap.FixedBufferAllocator;
 
 const Self = @This();
@@ -9,11 +10,10 @@ const Input = @import("../Input.zig");
 const GameOfLife = @import("../GameOfLife.zig");
 
 var buf: [256]u8 = undefined;
+var fba: FixedBufferAllocator = FixedBufferAllocator.init(&buf);
 
 resources: *Resources,
-
 cam: *raylib.Camera2D,
-fba: FixedBufferAllocator = FixedBufferAllocator.init(&buf),
 
 pub fn init(resources: *Resources) !Self {
     return Self{ .resources = resources, .cam = &resources.cam };
@@ -27,36 +27,26 @@ pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void
     _ = total_time;
     _ = delta_time;
 
-    if (input.isKeyPressed(.toggle_stop)) {
+    if (input.isActionJustPressed(.toggle_pause)) {
         Game.fromComponent(self).switchToState(.freeze_time);
-    } else if (input.isKeyPressed(.toggle_edit)) {
+    } else if (input.isActionJustPressed(.toggle_edit)) {
         Game.fromComponent(self).switchToState(.edit_grid);
-    } else if (input.isKeyPressed(.purge_life)) {
+    } else if (input.isActionJustPressed(.purge_life)) {
         self.resources.gol.cellPurgeProtocol();
     }
 
-    // Translate based on mouse right click
-    if (raylib.IsMouseButtonDown(.MOUSE_BUTTON_RIGHT)) {
+    if (input.isActionPressed(.translate_cam)) {
         var delta = raylib.GetMouseDelta();
         delta = raylib.Vector2Scale(delta, -1.0 / self.cam.zoom);
 
         self.cam.target = raylib.Vector2Add(self.cam.target, delta);
     }
 
-    // Zoom based on mouse wheel
     var wheel: f32 = raylib.GetMouseWheelMove();
-    if (wheel != 0) {
-        var mouse_world_pos = raylib.GetScreenToWorld2D(raylib.GetMousePosition(), self.cam.*);
-
-        self.cam.offset = raylib.GetMousePosition();
-
-        self.cam.target = mouse_world_pos;
-
-        const zoom_increment: f32 = 0.125;
-        self.cam.zoom += (wheel * zoom_increment);
-        if (self.cam.zoom < zoom_increment) {
-            self.cam.zoom = zoom_increment;
-        }
+    if (input.isActionPressed(.zoom_in) or wheel > 0) {
+        self.resources.zoomIn();
+    } else if (input.isActionPressed(.zoom_out) or wheel < 0) {
+        self.resources.zoomOut();
     }
 
     self.resources.gol.update();
@@ -69,7 +59,7 @@ pub fn render(self: *Self, total_time: f32, delta_time: f32) !void {
     raylib.BeginDrawing();
     defer {
         raylib.EndDrawing();
-        self.fba.reset();
+        fba.reset();
     }
 
     raylib.ClearBackground(raylib.RAYWHITE);
@@ -87,5 +77,5 @@ pub fn render(self: *Self, total_time: f32, delta_time: f32) !void {
         }
     }
 
-    raylib.DrawText(try raylib.TextFormat(self.fba.allocator(), "Gen: {d}", .{self.resources.gol.gen}), 10, 10, 20, raylib.DARKBLUE);
+    raylib.DrawText(try raylib.TextFormat(fba.allocator(), "Gen: {d}", .{self.resources.gol.gen}), 10, 10, 20, raylib.DARKBLUE);
 }

--- a/src/states/Running.zig
+++ b/src/states/Running.zig
@@ -5,6 +5,7 @@ const FixedBufferAllocator = std.heap.FixedBufferAllocator;
 const Self = @This();
 const Game = @import("../Game.zig");
 const Resources = @import("../Resources.zig");
+const Input = @import("../Input.zig");
 const GameOfLife = @import("../GameOfLife.zig");
 
 var buf: [256]u8 = undefined;
@@ -22,15 +23,15 @@ pub fn deinit(self: *Self) void {
     self.* = undefined;
 }
 
-pub fn update(self: *Self, total_time: f32, delta_time: f32) !void {
+pub fn update(self: *Self, input: Input, total_time: f32, delta_time: f32) !void {
     _ = total_time;
     _ = delta_time;
 
-    if (raylib.IsKeyPressed(.KEY_SPACE)) {
+    if (input.isKeyPressed(.toggle_stop)) {
         Game.fromComponent(self).switchToState(.freeze_time);
-    } else if (raylib.IsKeyPressed(.KEY_E)) {
+    } else if (input.isKeyPressed(.toggle_edit)) {
         Game.fromComponent(self).switchToState(.edit_grid);
-    } else if (raylib.IsKeyPressed(.KEY_K)) {
+    } else if (input.isKeyPressed(.purge_life)) {
         self.resources.gol.cellPurgeProtocol();
     }
 
@@ -66,7 +67,10 @@ pub fn render(self: *Self, total_time: f32, delta_time: f32) !void {
     _ = delta_time;
 
     raylib.BeginDrawing();
-    defer raylib.EndDrawing();
+    defer {
+        raylib.EndDrawing();
+        self.fba.reset();
+    }
 
     raylib.ClearBackground(raylib.RAYWHITE);
 
@@ -84,5 +88,4 @@ pub fn render(self: *Self, total_time: f32, delta_time: f32) !void {
     }
 
     raylib.DrawText(try raylib.TextFormat(self.fba.allocator(), "Gen: {d}", .{self.resources.gol.gen}), 10, 10, 20, raylib.DARKBLUE);
-    self.fba.reset();
 }


### PR DESCRIPTION
This PR introduces a new file, `Input.zig`, responsible for handling and triggering actions based on user input. The aim was to achieve a functionality akin to Godot's input system.

This implementation includes default keybindings defined in `Config.zig` using a hashmap, which are utilized in `Input.zig` to trigger actions. While the current setup suffices, there's a plan to transition to a separate config file in the future to enable persistence across changes.

Additionally, this pull request integrates the new input system across all states of the simulation, ensuring consistent behavior and interaction within each state.
